### PR TITLE
Use log crate instead of println to log out info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = "0.8.0"
 normalize-line-endings = "0.3.0"
 chardet = "0.2"
 encoding = "0.2.33"
+log = "0.4"
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate sha2;
 
 use encoding::label::encoding_from_whatwg_label;
 use encoding::DecoderTrap;
+use log::trace;
 use normalize_line_endings::normalized;
 use petgraph::algo::is_cyclic_directed;
 use petgraph::dot::Dot;
@@ -22,7 +23,6 @@ use std::io::Read;
 use std::iter::FromIterator;
 use std::path::Path;
 use std::path::PathBuf;
-use log::trace;
 
 pub fn decode_data_as_utf8(byte_str: &[u8], normalize_endings: bool) -> String {
     let result = chardet::detect(&byte_str);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use std::io::Read;
 use std::iter::FromIterator;
 use std::path::Path;
 use std::path::PathBuf;
+use log::trace;
 
 pub fn decode_data_as_utf8(byte_str: &[u8], normalize_endings: bool) -> String {
     let result = chardet::detect(&byte_str);
@@ -437,7 +438,7 @@ pub fn resolve_includes(text: &str, working_dir: &Path, include_dir: &Path) -> V
         let include_path = Path::new(&include.include_path);
         let exists = path_exists(&include_path);
         if !exists {
-            println!("Include path is invalid: {:?}", include_path);
+            trace!("Include path is invalid: {:?}", include_path);
         }
         exists
     });


### PR DESCRIPTION
Changes we've had for a long time. Instead of printing to stdout directly, redirect everything through the log crate.